### PR TITLE
Fix: setting date_gameplay_begins in jukejoint.

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import datetime
 # Change the sys path to locate a Talk of the Town repository
 PATH_TO_ANYTOWN = '../anytown'
 sys.path.append(PATH_TO_ANYTOWN)
@@ -18,7 +19,8 @@ THINKERS = set()
 def setup():
   game = Game()
   # Set date of gameplay to 1987
-  game.config.date_gameplay_begins = (1987, 10, 18)
+  date_gameplay_begins = (1987, 10, 18)
+  game.ordinal_date_that_gameplay_begins = ( datetime.date(*date_gameplay_begins).toordinal() )
   print "Simulating a town's history..."
   try:
       game.establish_setting()


### PR DESCRIPTION
- Setting the date_gameplay_begins via game.config did not work since
  the constructor of Game already uses the original date_gameplay_begins
  from the unmodified Config by the time jukejoint attempts to
  modify Config.
- Instead of modifying TOTT, I keep the changes local to jukejoint by
  importing datetime to force Game.ordinal_date_that_gameplay_begins to be
  the proper date.
